### PR TITLE
Adjust hero layout to prevent sticky header overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Personal branding site for Nathan Lee Jones — designer, developer, and storyteller."
+    />
+    <title>Nathan Lee Jones — Designer & Developer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav">
+        <a class="nav__brand" href="#top">Nathan Lee Jones</a>
+        <button class="nav__toggle" aria-expanded="false" aria-controls="nav-menu">
+          <span class="sr-only">Toggle navigation</span>
+          <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              d="M4 6h16M4 12h16M4 18h16"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+            />
+          </svg>
+        </button>
+        <div class="nav__links" id="nav-menu">
+          <a href="#about">About</a>
+          <a href="#experience">Experience</a>
+          <a href="#portfolio">Portfolio</a>
+          <a href="#contact">Contact</a>
+        </div>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero" id="top">
+        <div class="hero__badge">Available for select collaborations</div>
+        <h1 class="hero__title">
+          I design and build thoughtful digital experiences that help people
+          feel confident using technology.
+        </h1>
+        <p class="hero__subtitle">
+          I'm Nathan, a multidisciplinary designer and front-end developer who
+          pairs strategic thinking with craft. Over the last decade I've helped
+          startups and global brands turn complex problems into elegant,
+          human-centered products.
+        </p>
+        <div class="hero__cta">
+          <a class="btn btn--primary" href="#portfolio">View my work</a>
+          <a class="btn btn--ghost" href="#contact">Let's talk</a>
+        </div>
+        <ul class="hero__meta" aria-label="Key facts">
+          <li>
+            <span class="label">Location</span>
+            <span class="value">Melbourne, Australia</span>
+          </li>
+          <li>
+            <span class="label">Role</span>
+            <span class="value">Product Designer & Front-End Developer</span>
+          </li>
+          <li>
+            <span class="label">Focus</span>
+            <span class="value">Design systems, SaaS, storytelling</span>
+          </li>
+        </ul>
+      </section>
+      <section class="section section--alt" id="about">
+        <div class="section__heading">
+          <h2>About</h2>
+          <p>A balance of empathy, systems thinking, and delightful details.</p>
+        </div>
+        <div class="about__grid">
+          <p>
+            I believe the best products blend clarity with personality. My
+            approach combines research, storytelling, and iterative prototyping
+            to uncover insight and transform it into intuitive, inclusive
+            experiences.
+          </p>
+          <p>
+            When I'm not in Figma or VS Code, you'll find me photographing city
+            textures, recording music, or mentoring emerging designers through
+            community programs.
+          </p>
+          <dl class="about__details">
+            <div>
+              <dt>Tools of choice</dt>
+              <dd>Figma, Webflow, VS Code, Notion, Adobe CC</dd>
+            </div>
+            <div>
+              <dt>Currently learning</dt>
+              <dd>Creative coding with WebGL and AI-assisted workflows</dd>
+            </div>
+            <div>
+              <dt>Values</dt>
+              <dd>Curiosity, generosity, intentionality, play</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <section class="section" id="experience">
+        <div class="section__heading">
+          <h2>Experience</h2>
+          <p>Highlights from a decade of designing for impact.</p>
+        </div>
+        <div class="experience__timeline">
+          <article class="timeline-card">
+            <h3>Principal Product Designer · Current</h3>
+            <p class="timeline-card__meta">Freelance · 2022 — Present</p>
+            <p>
+              Partnering with emerging SaaS teams to build product narratives,
+              shape end-to-end experiences, and launch cohesive design systems.
+            </p>
+          </article>
+          <article class="timeline-card">
+            <h3>Design Lead</h3>
+            <p class="timeline-card__meta">Storycraft Labs · 2018 — 2022</p>
+            <p>
+              Led cross-functional teams delivering immersive digital platforms
+              for entertainment brands, driving a 40% lift in user retention.
+            </p>
+          </article>
+          <article class="timeline-card">
+            <h3>Senior UX Designer</h3>
+            <p class="timeline-card__meta">Latitude Financial · 2014 — 2018</p>
+            <p>
+              Shipped a suite of human-centered fintech tools across mobile and
+              web, balancing regulatory compliance with joyful storytelling.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section section--alt" id="portfolio">
+        <div class="section__heading">
+          <h2>Selected Work</h2>
+          <p>A sampling of projects where strategy meets craft.</p>
+        </div>
+        <div class="portfolio__grid">
+          <article class="portfolio-card">
+            <div class="portfolio-card__tag">Design System</div>
+            <h3>Orbit</h3>
+            <p>
+              Built a modular, accessible design language for a fintech startup,
+              enabling the team to ship features twice as fast.
+            </p>
+            <a class="portfolio-card__link" href="#contact">Explore the case study</a>
+          </article>
+          <article class="portfolio-card">
+            <div class="portfolio-card__tag">Product Strategy</div>
+            <h3>Wayfarer</h3>
+            <p>
+              Reimagined the onboarding experience for a travel platform,
+              increasing activation by 27% through narrative-driven flows.
+            </p>
+            <a class="portfolio-card__link" href="#contact">Explore the case study</a>
+          </article>
+          <article class="portfolio-card">
+            <div class="portfolio-card__tag">Storytelling</div>
+            <h3>Signals</h3>
+            <p>
+              Crafted an interactive editorial microsite blending motion and
+              data visualization to illuminate climate research.
+            </p>
+            <a class="portfolio-card__link" href="#contact">Explore the case study</a>
+          </article>
+        </div>
+      </section>
+
+      <section class="section" id="testimonials">
+        <div class="section__heading">
+          <h2>Notes of Appreciation</h2>
+          <p>Words from collaborators and clients.</p>
+        </div>
+        <div class="testimonials">
+          <figure class="testimonial">
+            <blockquote>
+              “Nathan has a rare ability to translate ambiguity into clarity.
+              Our product roadmap is sharper because of his leadership.”
+            </blockquote>
+            <figcaption>— Mia Chen, VP Product at Storycraft Labs</figcaption>
+          </figure>
+          <figure class="testimonial">
+            <blockquote>
+              “He makes design systems feel like poetry — deeply intentional,
+              human, and scalable.”
+            </blockquote>
+            <figcaption>— Jordan Patel, Director of Design at Orbit</figcaption>
+          </figure>
+        </div>
+      </section>
+
+      <section class="section section--alt" id="contact">
+        <div class="section__heading">
+          <h2>Let's collaborate</h2>
+          <p>
+            Share a few details about your project and I'll reach out within two
+            business days.
+          </p>
+        </div>
+        <form class="contact-form">
+          <div class="form__group">
+            <label for="name">Name</label>
+            <input id="name" name="name" type="text" placeholder="Jane Doe" />
+          </div>
+          <div class="form__group">
+            <label for="email">Email</label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              placeholder="jane@studio.com"
+            />
+          </div>
+          <div class="form__group">
+            <label for="project">Project details</label>
+            <textarea
+              id="project"
+              name="project"
+              rows="4"
+              placeholder="Tell me about what you're building..."
+            ></textarea>
+          </div>
+          <button class="btn btn--primary" type="submit">Send message</button>
+        </form>
+        <div class="contact__meta">
+          <p>
+            Prefer email? Reach me directly at
+            <a href="mailto:hello@nathanleejones.com">hello@nathanleejones.com</a>.
+          </p>
+          <ul class="contact__social" aria-label="Social links">
+            <li><a href="https://dribbble.com" target="_blank" rel="noreferrer">Dribbble</a></li>
+            <li><a href="https://www.linkedin.com" target="_blank" rel="noreferrer">LinkedIn</a></li>
+            <li><a href="https://www.instagram.com" target="_blank" rel="noreferrer">Instagram</a></li>
+          </ul>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>© <span id="year"></span> Nathan Lee Jones. Built with curiosity and care.</p>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,28 @@
+const navToggle = document.querySelector('.nav__toggle');
+const navLinks = document.querySelector('.nav__links');
+const yearEl = document.getElementById('year');
+
+if (navToggle && navLinks) {
+  navToggle.addEventListener('click', () => {
+    const isOpen = navLinks.classList.toggle('is-open');
+    navToggle.setAttribute('aria-expanded', isOpen);
+  });
+}
+
+if (yearEl) {
+  yearEl.textContent = new Date().getFullYear();
+}
+
+const links = document.querySelectorAll('a[href^="#"]');
+links.forEach((link) => {
+  link.addEventListener('click', (event) => {
+    const targetId = link.getAttribute('href')?.substring(1);
+    const targetEl = targetId && document.getElementById(targetId);
+    if (targetEl) {
+      event.preventDefault();
+      targetEl.scrollIntoView({ behavior: 'smooth' });
+      navLinks?.classList.remove('is-open');
+      navToggle?.setAttribute('aria-expanded', 'false');
+    }
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,460 @@
+:root {
+  color-scheme: light;
+  --bg: #f8f7f3;
+  --bg-alt: #ffffff;
+  --text: #1f2933;
+  --muted: #546a7b;
+  --accent: #ec7755;
+  --accent-dark: #d45f3e;
+  --border: #e2e8f0;
+  --shadow: 0px 20px 60px rgba(15, 23, 42, 0.12);
+  --max-width: 1100px;
+  --radius: 18px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.site-header {
+  background: var(--bg-alt);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(8px);
+}
+
+.nav {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.nav__brand {
+  font-weight: 600;
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
+}
+
+.nav__links {
+  display: flex;
+  gap: 1.5rem;
+  font-weight: 500;
+}
+
+.nav__links a {
+  position: relative;
+  padding-bottom: 0.25rem;
+}
+
+.nav__links a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+
+.nav__links a:hover::after,
+.nav__links a:focus::after {
+  transform: scaleX(1);
+}
+
+.nav__toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.hero {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 6rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(236, 119, 85, 0.12);
+  color: var(--accent);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  width: fit-content;
+}
+
+.hero__title {
+  font-size: clamp(2.5rem, 5vw, 3.8rem);
+  line-height: 1.15;
+  margin: 0;
+}
+
+.hero__subtitle {
+  font-size: 1.08rem;
+  max-width: 60ch;
+  color: var(--muted);
+  margin: 0;
+}
+
+.hero__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.hero__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.hero__meta li {
+  background: var(--bg-alt);
+  padding: 1.25rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.hero__meta .label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+}
+
+.hero__meta .value {
+  font-weight: 600;
+}
+
+.section {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 5rem 1.5rem;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.section--alt {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.82), #fffaf3);
+  border-radius: var(--radius);
+  margin-top: 3rem;
+  box-shadow: var(--shadow);
+}
+
+.section__heading h2 {
+  font-size: 2rem;
+  margin: 0 0 0.5rem;
+}
+
+.section__heading p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.about__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2rem;
+  align-items: start;
+}
+
+.about__details {
+  display: grid;
+  gap: 1.5rem;
+  margin: 0;
+}
+
+.about__details dt {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+.about__details dd {
+  margin: 0.35rem 0 0;
+  font-weight: 500;
+}
+
+.experience__timeline {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline-card {
+  background: var(--bg-alt);
+  padding: 1.75rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.timeline-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1.2rem;
+}
+
+.timeline-card__meta {
+  margin: 0 0 1rem;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.portfolio__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.portfolio-card {
+  background: var(--bg-alt);
+  padding: 1.75rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.portfolio-card__tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(236, 119, 85, 0.15);
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.portfolio-card__link {
+  margin-top: 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-weight: 600;
+}
+
+.portfolio-card__link::after {
+  content: "→";
+  transition: transform 0.2s ease;
+}
+
+.portfolio-card__link:hover::after,
+.portfolio-card__link:focus::after {
+  transform: translateX(3px);
+}
+
+.testimonials {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.testimonial {
+  margin: 0;
+  background: var(--bg-alt);
+  padding: 1.75rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.testimonial blockquote {
+  margin: 0 0 1rem;
+  font-size: 1.05rem;
+  font-style: italic;
+}
+
+.contact-form {
+  display: grid;
+  gap: 1.5rem;
+  background: var(--bg-alt);
+  padding: 2rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.form__group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+label {
+  font-weight: 600;
+}
+
+input,
+textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  font: inherit;
+  background: #fff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(236, 119, 85, 0.2);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn--primary {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: var(--shadow);
+}
+
+.btn--primary:hover,
+.btn--primary:focus {
+  background: var(--accent-dark);
+  transform: translateY(-1px);
+}
+
+.btn--ghost {
+  background: transparent;
+  border: 1.5px solid var(--border);
+}
+
+.btn--ghost:hover,
+.btn--ghost:focus {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.contact__meta {
+  display: grid;
+  gap: 1rem;
+  color: var(--muted);
+}
+
+.contact__social {
+  display: flex;
+  gap: 1.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.site-footer {
+  text-align: center;
+  padding: 3rem 1.5rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+@media (max-width: 768px) {
+  .nav {
+    flex-wrap: wrap;
+  }
+
+  .nav__toggle {
+    display: inline-flex;
+  }
+
+  .nav__links {
+    width: 100%;
+    flex-direction: column;
+    gap: 0.75rem;
+    display: none;
+  }
+
+  .nav__links.is-open {
+    display: flex;
+  }
+
+  .section {
+    padding: 4rem 1.25rem;
+  }
+
+  .section--alt {
+    border-radius: 0;
+  }
+
+  .hero {
+    padding-top: 5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- move the hero section out of the sticky header so only the navigation remains fixed
- ensure the main content scrolls normally beneath the top navigation bar

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d97b421ab08327a3216e53de7ba8db